### PR TITLE
Fixed trying to read unloaded configs

### DIFF
--- a/src/main/java/yuuki1293/pccard/ConfigClient.java
+++ b/src/main/java/yuuki1293/pccard/ConfigClient.java
@@ -24,17 +24,7 @@ public class ConfigClient {
         spec = builder.build();
     }
 
-    public static boolean jeiIntegration;
-
-    @SubscribeEvent
-    static void onLoad(final ModConfigEvent.Loading event)
-    {
-        jeiIntegration = JEI_INTEGRATION.get();
-    }
-
-    @SubscribeEvent
-    static void onReLoad(final ModConfigEvent.Reloading event)
-    {
-        jeiIntegration = JEI_INTEGRATION.get();
+    public static boolean getJeiIntegration() {
+        return JEI_INTEGRATION.get();
     }
 }

--- a/src/main/java/yuuki1293/pccard/ConfigCommon.java
+++ b/src/main/java/yuuki1293/pccard/ConfigCommon.java
@@ -25,17 +25,7 @@ public class ConfigCommon {
         spec = builder.build();
     }
 
-    public static int searchDepth;
-
-    @SubscribeEvent
-    static void onLoad(final ModConfigEvent.Loading event)
-    {
-        searchDepth = SEARCH_DEPTH.get();
-    }
-
-    @SubscribeEvent
-    static void onReLoad(final ModConfigEvent.Reloading event)
-    {
-        searchDepth = SEARCH_DEPTH.get();
+    public static int getSearchDepth() {
+        return SEARCH_DEPTH.get();
     }
 }

--- a/src/main/java/yuuki1293/pccard/impl/PatternProviderLogicImpl.java
+++ b/src/main/java/yuuki1293/pccard/impl/PatternProviderLogicImpl.java
@@ -110,7 +110,7 @@ public class PatternProviderLogicImpl {
             int depth = current.getB();
 
             // Skip if already visited or if depth exceeds configured limit
-            if (visited.contains(posDir) || depth > ConfigCommon.searchDepth) {
+            if (visited.contains(posDir) || depth > ConfigCommon.getSearchDepth()) {
                 continue;
             }
 

--- a/src/main/java/yuuki1293/pccard/mixins/common/MixinAe2PatternTerminalHandler.java
+++ b/src/main/java/yuuki1293/pccard/mixins/common/MixinAe2PatternTerminalHandler.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 public abstract class MixinAe2PatternTerminalHandler {
     @Inject(method = "ofInputs", at = @At("RETURN"), cancellable = true)
     private static void ofInputs(EmiRecipe emiRecipe, CallbackInfoReturnable<List<List<GenericStack>>> cir) {
-        if(!ConfigClient.jeiIntegration) return; // config
+        if(!ConfigClient.getJeiIntegration()) return; // config
 
         var inputs = cir.getReturnValue();
 

--- a/src/main/java/yuuki1293/pccard/mixins/common/MixinGenericEntryStackHelperJEI.java
+++ b/src/main/java/yuuki1293/pccard/mixins/common/MixinGenericEntryStackHelperJEI.java
@@ -27,7 +27,7 @@ public abstract class MixinGenericEntryStackHelperJEI {
 
     @Inject(method = "ofInputs", at = @At("TAIL"), cancellable = true)
     private static void ofInputs(IRecipeSlotsView recipeLayout, CallbackInfoReturnable<List<List<GenericStack>>> cir) {
-        if (!ConfigClient.jeiIntegration) return; // config
+        if (!ConfigClient.getJeiIntegration()) return; // config
 
         var inputs = cir.getReturnValue();
 


### PR DESCRIPTION
This PR simply changes configs to be read as needed, instead of every load/reload.
Fixes initializing error that tried to read unloaded configs.