### PR TITLE
Fix Expanded AE Smart Blocking compatibility with programmed circuits

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,10 +141,17 @@ repositories {
         }
     }
     maven {
-        name = "Modrinth"
-        url = uri("https://api.modrinth.com/maven")
+        name = "Gnomecraft"
+        url = uri("https://maven.gnomecraft.net/releases/")
         content {
-            includeGroup ("maven.modrinth")
+            includeGroup ("dev.emi")
+        }
+    }
+    maven {
+        name = "TerraformersMC"
+        url = uri("https://maven.terraformersmc.com/")
+        content {
+            includeGroup ("dev.emi")
         }
     }
     maven {
@@ -194,7 +201,7 @@ dependencies {
 //    modRuntimeOnly (libs.konkrete) // depended by FancyMenu
 
     modImplementation (libs.jei) // JEI
-    modCompileOnly (libs.emi) // EMI
+    modCompileOnly (variantOf(libs.emi, "api")) // EMI
     modRuntimeOnly (libs.emi) // EMI
     modCompileOnly (libs.registrate) // Registrate
     modCompileOnly (libs.ldlib) { isTransitive = false } // ldlib

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,10 +141,10 @@ repositories {
         }
     }
     maven {
-        name = "TerraformersMC"
-        url = uri("https://maven.terraformersmc.com/")
+        name = "Modrinth"
+        url = uri("https://api.modrinth.com/maven")
         content {
-            includeGroup ("dev.emi")
+            includeGroup ("maven.modrinth")
         }
     }
     maven {
@@ -194,7 +194,7 @@ dependencies {
 //    modRuntimeOnly (libs.konkrete) // depended by FancyMenu
 
     modImplementation (libs.jei) // JEI
-    modCompileOnly (variantOf(libs.emi, "api")) // EMI
+    modCompileOnly (libs.emi) // EMI
     modRuntimeOnly (libs.emi) // EMI
     modCompileOnly (libs.registrate) // Registrate
     modCompileOnly (libs.ldlib) { isTransitive = false } // ldlib

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ fancymenu = "8094800"
 melody = "5109692"
 konkrete = "5028413"
 jei = "15.20.0.115"
-emi = "1.1.22+1.20.1+forge"
+emi = "1.1.22+1.20.1"
 registrate = "MC1.20-1.3.3"
 ldlib = "1.0.31"
 adae = "6757852"
@@ -69,7 +69,7 @@ fancymenu = { module = "curse.maven:fancymenu-367706", version.ref = "fancymenu"
 melody = { module = "curse.maven:melody-938643", version.ref = "melody" }
 konkrete = { module = "curse.maven:konkrete-410295", version.ref = "konkrete" }
 jei = { module = "mezz.jei:jei-1.20.1-forge", version.ref = "jei" }
-emi = { module = "maven.modrinth:emi", version.ref = "emi" }
+emi = { module = "dev.emi:emi-forge", version.ref = "emi" }
 registrate = { module = "com.tterrag.registrate:Registrate", version.ref = "registrate" }
 ldlib = { module = "com.lowdragmc.ldlib:ldlib-forge-1.20.1", version.ref = "ldlib" }
 adae = { module = "curse.maven:advancedae-1084104", version.ref = "adae" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ fancymenu = "8094800"
 melody = "5109692"
 konkrete = "5028413"
 jei = "15.20.0.115"
-emi = "1.1.22+1.20.1"
+emi = "1.1.22+1.20.1+forge"
 registrate = "MC1.20-1.3.3"
 ldlib = "1.0.31"
 adae = "6757852"
@@ -69,7 +69,7 @@ fancymenu = { module = "curse.maven:fancymenu-367706", version.ref = "fancymenu"
 melody = { module = "curse.maven:melody-938643", version.ref = "melody" }
 konkrete = { module = "curse.maven:konkrete-410295", version.ref = "konkrete" }
 jei = { module = "mezz.jei:jei-1.20.1-forge", version.ref = "jei" }
-emi = { module = "dev.emi:emi-forge", version.ref = "emi" }
+emi = { module = "maven.modrinth:emi", version.ref = "emi" }
 registrate = { module = "com.tterrag.registrate:Registrate", version.ref = "registrate" }
 ldlib = { module = "com.lowdragmc.ldlib:ldlib-forge-1.20.1", version.ref = "ldlib" }
 adae = { module = "curse.maven:advancedae-1084104", version.ref = "adae" }

--- a/src/main/java/yuuki1293/pccard/impl/PatternProviderLogicImpl.java
+++ b/src/main/java/yuuki1293/pccard/impl/PatternProviderLogicImpl.java
@@ -32,6 +32,7 @@ import appeng.api.implementations.blockentities.ICraftingMachine;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.parts.IPartHost;
+import appeng.api.stacks.AEItemKey;
 import appeng.parts.storagebus.StorageBusPart;
 import yuuki1293.pccard.ConfigCommon;
 import yuuki1293.pccard.TagUtils;
@@ -58,6 +59,14 @@ public class PatternProviderLogicImpl {
         }
 
         return newStack;
+    }
+
+    public static void addCircuitToPatternInputs(IPatternDetails patternDetails, Set<appeng.api.stacks.AEKey> inputs) {
+        var definitionTag = patternDetails.getDefinition()
+            .getTag();
+        if (definitionTag != null && definitionTag.contains(NBT_CIRCUIT)) {
+            inputs.add(AEItemKey.of(IntCircuitBehaviour.stack(definitionTag.getInt(NBT_CIRCUIT))));
+        }
     }
 
     public static void setPCNumber(IPatternDetails patternDetails, BlockEntity be, List<BlockPos> blockPoses) {

--- a/src/main/java/yuuki1293/pccard/mixins/PCCardMixinPlugin.java
+++ b/src/main/java/yuuki1293/pccard/mixins/PCCardMixinPlugin.java
@@ -57,6 +57,12 @@ public class PCCardMixinPlugin implements IMixinConfigPlugin {
                 "yuuki1293.pccard.mixins.advanced_ae.MixinAdvPatternProviderScreen",
                 "yuuki1293.pccard.mixins.advanced_ae.MixinAdvProcessingPattern",
                 "yuuki1293.pccard.mixins.advanced_ae.MixinSmallAdvPatternProviderScreen"));
+
+        LOAD_WHEN_MOD_PRESENT.put(
+            "expandedae",
+            Set.of(
+                "yuuki1293.pccard.mixins.expandedae.AccessorExpandedPatternProviderTargetCache",
+                "yuuki1293.pccard.mixins.expandedae.MixinExpandedPatternProviderTarget"));
     }
 
     @Override

--- a/src/main/java/yuuki1293/pccard/mixins/common/MixinPatternProviderLogic.java
+++ b/src/main/java/yuuki1293/pccard/mixins/common/MixinPatternProviderLogic.java
@@ -1,5 +1,8 @@
 package yuuki1293.pccard.mixins.common;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 
@@ -13,6 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import com.llamalad7.mixinextras.sugar.Local;
 
 import appeng.api.crafting.IPatternDetails;
+import appeng.api.stacks.AEKey;
 import appeng.api.upgrades.IUpgradeableObject;
 import appeng.helpers.patternprovider.PatternProviderLogic;
 import appeng.helpers.patternprovider.PatternProviderLogicHost;
@@ -38,6 +42,18 @@ public abstract class MixinPatternProviderLogic implements IUpgradeableObject {
         if (!isUpgradedWith(PCCard.PROGRAMMED_CIRCUIT_CARD_ITEM.get())) return stack;
 
         return PatternProviderLogicImpl.updatePatterns(stack);
+    }
+
+    @ModifyArg(
+        method = "pushPattern",
+        at = @At(
+            value = "INVOKE",
+            target = "Lappeng/helpers/patternprovider/PatternProviderTarget;containsPatternInput(Ljava/util/Set;)Z"))
+    private Set<AEKey> includeProgrammedCircuit(Set<AEKey> patternInputs,
+        @Local(ordinal = 0, argsOnly = true) IPatternDetails patternDetails) {
+        var result = new HashSet<>(patternInputs);
+        PatternProviderLogicImpl.addCircuitToPatternInputs(patternDetails, result);
+        return result;
     }
 
     @Inject(

--- a/src/main/java/yuuki1293/pccard/mixins/expandedae/AccessorExpandedPatternProviderTargetCache.java
+++ b/src/main/java/yuuki1293/pccard/mixins/expandedae/AccessorExpandedPatternProviderTargetCache.java
@@ -1,0 +1,14 @@
+package yuuki1293.pccard.mixins.expandedae;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import appeng.util.ConfigManager;
+import lu.kolja.expandedae.api.patternprovider.PatternProviderTargetCache;
+
+@Mixin(value = PatternProviderTargetCache.class, remap = false)
+public interface AccessorExpandedPatternProviderTargetCache {
+
+    @Accessor("configManager")
+    ConfigManager pCCard$getConfigManager();
+}

--- a/src/main/java/yuuki1293/pccard/mixins/expandedae/MixinExpandedPatternProviderTarget.java
+++ b/src/main/java/yuuki1293/pccard/mixins/expandedae/MixinExpandedPatternProviderTarget.java
@@ -1,0 +1,74 @@
+package yuuki1293.pccard.mixins.expandedae;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import appeng.api.stacks.AEKey;
+import appeng.api.storage.MEStorage;
+import lu.kolja.expandedae.api.patternprovider.PatternProviderTargetCache;
+import lu.kolja.expandedae.definition.ExpSettings;
+import lu.kolja.expandedae.enums.BlockingMode;
+
+@Mixin(targets = "lu.kolja.expandedae.api.patternprovider.PatternProviderTargetCache$1", remap = false)
+public class MixinExpandedPatternProviderTarget {
+
+    @Unique
+    private static Field pCCard$storageField;
+    @Unique
+    private static Field pCCard$ownerField;
+
+    @Inject(method = "containsPatternInput", at = @At("HEAD"), cancellable = true)
+    private void compareProgrammedCircuit(Set<AEKey> patternInputs, CallbackInfoReturnable<Boolean> cir) {
+        var storage = pCCard$getField("val$storage", MEStorage.class, true);
+        var owner = pCCard$getField("this$0", PatternProviderTargetCache.class, false);
+        if (storage == null || owner == null) return;
+
+        var configManager = ((AccessorExpandedPatternProviderTargetCache) (Object) owner).pCCard$getConfigManager();
+        if (configManager.getSetting(ExpSettings.BLOCKING_MODE) != BlockingMode.SMART) return;
+
+        var hasRecipeInputs = false;
+        var circuitMatches = true;
+        for (var stack : storage.getAvailableStacks()) {
+            var key = stack.getKey();
+            if (
+                key.getId()
+                    .getNamespace()
+                    .equals("gtceu")
+                    && key.getId()
+                        .getPath()
+                        .equals("programmed_circuit")
+            ) {
+                circuitMatches = patternInputs.contains(key);
+                continue;
+            }
+            hasRecipeInputs = true;
+            if (!patternInputs.contains(key.dropSecondary())) {
+                cir.setReturnValue(true);
+                return;
+            }
+        }
+        cir.setReturnValue(hasRecipeInputs && !circuitMatches);
+    }
+
+    @Unique
+    private <T> T pCCard$getField(String name, Class<T> type, boolean storageField) {
+        try {
+            var field = storageField ? pCCard$storageField : pCCard$ownerField;
+            if (field == null) {
+                field = getClass().getDeclaredField(name);
+                field.setAccessible(true);
+                if (storageField) pCCard$storageField = field;
+                else pCCard$ownerField = field;
+            }
+            return type.cast(field.get(this));
+        } catch (ReflectiveOperationException | ClassCastException ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/templates/template.mixins.json
+++ b/src/main/templates/template.mixins.json
@@ -23,7 +23,9 @@
     "common.MixinPatternP2PTunnelLogic",
     "common.MixinPatternProviderLogic",
     "common.MixinPatternProviderLogicHost",
-    "common.MixinPatternProviderMenu"
+    "common.MixinPatternProviderMenu",
+    "expandedae.AccessorExpandedPatternProviderTargetCache",
+    "expandedae.MixinExpandedPatternProviderTarget"
   ],
   "client": [
     "advanced_ae.MixinAdvPatternProviderScreen",


### PR DESCRIPTION
## Summary

Add optional Expanded AE compatibility so Smart Blocking distinguishes processing patterns by Programmed Circuit Card's stored GT circuit configuration.

## Root cause

PCC removes `gtceu:programmed_circuit` from the ordinary processing-pattern inputs and stores the selected circuit under the pattern definition's `circuit` tag. Expanded AE Smart Blocking compares only `IPatternDetails#getInputs()` and skips the programmed-circuit stack in the target inventory, so otherwise-identical patterns using different circuits are treated as compatible.

## Changes

- Reconstruct the configured GT programmed-circuit key from PCC's `circuit` metadata and add it to the Smart Blocking comparison set.
- Load the Expanded AE mixins only when `expandedae` is installed.
- Compare programmed circuits with their NBT intact while retaining Expanded AE's existing comparison behavior for real recipe inputs.
- Block a mismatched circuit while real recipe inputs remain, but allow a direct circuit switch when the target contains only a stale ghost circuit.
- Leave Expanded AE's other blocking modes unchanged.

## Result

| Target contents | Circuit comparison | Result |
| --- | --- | --- |
| Matching real inputs | Same circuit | Allow batching/parallels |
| Matching real inputs | Different circuit | Block |
| Unrelated real inputs | Any circuit | Block |
| No real inputs; only stale circuit | Different circuit | Allow direct switch |

## Validation

- `gradlew.bat build --no-configuration-cache` passes with Temurin JDK 21.
- Tested in Minecraft 1.20.1 with AE2 15.4.10, PCC 1.2.10, Expanded AE 1.4.1.b, and the Star Technology GTCEu fork 1.7.0b.
- Verified different-circuit patterns do not overwrite an active batch.
- Verified the next AE2 crafting task proceeds automatically after real inputs are consumed, without manually clearing the retained circuit.
