### PR TITLE
Fix nested Pattern P2P destination tracking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -235,6 +235,7 @@ dependencies {
     }
 
     annotationProcessor(variantOf(libs.mixin, "processor"))
+    testCompileOnly(libs.mixin)
     libs.mixinExtrasCommon.let {
         annotationProcessor(it)
         modCompileOnly(it)
@@ -497,6 +498,12 @@ val patternBufferPolicySelfCheck = tasks.register<JavaExec>("patternBufferPolicy
     mainClass = "yuuki1293.pccard.impl.PatternBufferBlockingPolicySelfCheck"
 }
 
+val patternP2PDestinationTimingSelfCheck = tasks.register<JavaExec>("patternP2PDestinationTimingSelfCheck") {
+    dependsOn(tasks.named("testClasses"))
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass = "yuuki1293.pccard.mixins.common.PatternP2PDestinationTimingSelfCheck"
+}
+
 tasks.named("check") {
-    dependsOn(patternBufferPolicySelfCheck)
+    dependsOn(patternBufferPolicySelfCheck, patternP2PDestinationTimingSelfCheck)
 }

--- a/src/main/java/yuuki1293/pccard/impl/PatternProviderLogicImpl.java
+++ b/src/main/java/yuuki1293/pccard/impl/PatternProviderLogicImpl.java
@@ -200,7 +200,9 @@ public class PatternProviderLogicImpl {
                 if (craftingMachine instanceof IPatternP2PTunnelLogicMixin patternP2P) {
                     var patternP2PPos = patternP2P.pCCard$getLastBlockPos();
                     var patternP2PDirection = patternP2P.pCCard$getLastDirection();
-                    return new Tuple<>(patternP2PPos, patternP2PDirection);
+                    if (patternP2PPos != null && patternP2PDirection != null) {
+                        return new Tuple<>(patternP2PPos, patternP2PDirection);
+                    }
                 }
             }
 

--- a/src/main/java/yuuki1293/pccard/mixins/common/MixinPatternP2PTunnelLogic.java
+++ b/src/main/java/yuuki1293/pccard/mixins/common/MixinPatternP2PTunnelLogic.java
@@ -30,7 +30,8 @@ public abstract class MixinPatternP2PTunnelLogic implements IPatternP2PTunnelLog
         method = "pushPattern",
         at = @At(
             value = "INVOKE",
-            target = "Lappeng/api/implementations/blockentities/ICraftingMachine;pushPattern(Lappeng/api/crafting/IPatternDetails;[Lappeng/api/stacks/KeyCounter;Lnet/minecraft/core/Direction;)Z"))
+            target = "Lappeng/api/implementations/blockentities/ICraftingMachine;pushPattern(Lappeng/api/crafting/IPatternDetails;[Lappeng/api/stacks/KeyCounter;Lnet/minecraft/core/Direction;)Z",
+            shift = At.Shift.AFTER))
     public void pushPattern(CallbackInfoReturnable<Boolean> cir, @Local ICraftingMachine craftingMachine) {
         if (craftingMachine instanceof IPatternP2PTunnelLogicMixin patternP2PTunnelLogicMixin) {
             this.pCCard$lastBlockPos = patternP2PTunnelLogicMixin.pCCard$getLastBlockPos();

--- a/src/test/java/yuuki1293/pccard/mixins/common/PatternP2PDestinationTimingSelfCheck.java
+++ b/src/test/java/yuuki1293/pccard/mixins/common/PatternP2PDestinationTimingSelfCheck.java
@@ -1,0 +1,24 @@
+package yuuki1293.pccard.mixins.common;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public final class PatternP2PDestinationTimingSelfCheck {
+
+    private PatternP2PDestinationTimingSelfCheck() {}
+
+    public static void main(String[] args) throws IOException {
+        var classFile = MixinPatternP2PTunnelLogic.class.getResourceAsStream("MixinPatternP2PTunnelLogic.class");
+        if (classFile == null) throw new AssertionError("Missing Pattern P2P mixin class file");
+
+        var bytecode = new String(classFile.readAllBytes(), StandardCharsets.ISO_8859_1);
+        require(bytecode.contains("ICraftingMachine;pushPattern"), "Missing nested Pattern P2P tracking injection");
+        require(
+            bytecode.contains("AFTER"),
+            "Nested Pattern P2P destination is captured before the nested push selects its current output");
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) throw new AssertionError(message);
+    }
+}


### PR DESCRIPTION
Fixes #54

## Problem
Nested MAE2 Pattern P2P destinations were copied before the nested `pushPattern` call selected its current output. That left stale or null position/direction data and broke subsequent subnet traversal.

## Fix
- capture nested Pattern P2P destination state after the nested push returns
- ignore incomplete tracked destinations and fall back to the adjacent target
- add a regression self-check for the injection timing

## Verification
- confirmed the regression self-check fails against the old injection timing
- `./gradlew --no-daemon patternP2PDestinationTimingSelfCheck`
- `./gradlew --no-daemon check build`

## AI disclosure
This fix and its regression test were generated by Hermes Agent (AI) and verified locally.